### PR TITLE
Recalculate `empty` on timeout and queue

### DIFF
--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -26,9 +26,12 @@ class Semaphore {
       waiting.timer = setTimeout(() => {
         waiting.resolve = null;
         this.queue.shift();
+        const { counter, concurrency } = this;
+        this.empty = this.queue.length === 0 && counter === concurrency;
         reject(new Error('Semaphore timeout'));
       }, this.timeout);
       this.queue.push(waiting);
+      this.empty = false;
     });
   }
 
@@ -41,7 +44,8 @@ class Semaphore {
     const { resolve, timer } = this.queue.shift();
     clearTimeout(timer);
     if (resolve) setTimeout(resolve, 0);
-    this.empty = this.queue.length === 0 && this.counter === this.concurrency;
+    const { counter, concurrency } = this;
+    this.empty = this.queue.length === 0 && counter === concurrency;
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
