### PR TITLE
Remove useless parameter for Math.round in bytesToSize

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -122,7 +122,7 @@ const bytesToSize = (bytes) => {
   if (bytes === 0) return '0';
   const exp = Math.floor(Math.log(bytes) / Math.log(1000));
   const size = bytes / 1000 ** exp;
-  const short = Math.round(size, 2);
+  const short = Math.round(size);
   const unit = exp === 0 ? '' : ' ' + SIZE_UNITS[exp - 1];
   return short.toString() + unit;
 };


### PR DESCRIPTION
#63 

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
