### PR TITLE
Replace `any` type with generic

### DIFF
--- a/metautil.d.ts
+++ b/metautil.d.ts
@@ -21,7 +21,7 @@ export function validatePassword(
 ): Promise<boolean>;
 
 export function random(min: number, max?: number): number;
-export function sample(arr: Array<any>): any;
+export function sample<T>(arr: Array<T>): T;
 export function ipToInt(ip?: string): number;
 export function parseHost(host?: string): string;
 export function parseParams(params: string): object;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] update .d.ts typings

We shouldn't use `any` to define `sample` function coz we're actually losing type information.

Example:
```ts
const list = [true, 1n, 'string'];

const a = sample(list);
// ts calculates the type of variable as `any`
// after the proposed changes, ts will be able to infer `boolean | bigint | string`
```
