### PR TITLE
Use native `fetch` from node.js if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Optimize `fileExt`
+- Use native `fetch` from node.js if available
 - Fix `fetch` polyfill to be compatible with node.js `fetch` implementation
 - Use `receiveBody` in `fetch` polyfill
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -32,7 +32,7 @@ const prepareResponse = (resolve, reject) => (res) => {
     .catch(reject);
 };
 
-const fetch = (url, options = {}) => {
+const fetchPolyfill = (url, options = {}) => {
   const protocol = url.startsWith('https') ? https : http;
   return new Promise((resolve, reject) => {
     const { body, headers } = prepareRequest(options);
@@ -44,4 +44,4 @@ const fetch = (url, options = {}) => {
   });
 };
 
-module.exports = { fetch, receiveBody };
+module.exports = { fetch: fetch || fetchPolyfill, receiveBody };

--- a/lib/network.js
+++ b/lib/network.js
@@ -44,4 +44,4 @@ const fetchPolyfill = (url, options = {}) => {
   });
 };
 
-module.exports = { fetch: fetch || fetchPolyfill, receiveBody };
+module.exports = { fetch: global.fetch || fetchPolyfill, receiveBody };


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
