### PR TITLE
Improve `AbortController` polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Add `generateUUID` implementation
+- Improve `AbortController` polyfill and use native if available
 
 ## [3.6.0][] - 2022-12-19
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -2,13 +2,38 @@
 
 const { EventEmitter } = require('node:events');
 
-const createAbortController = () => {
-  const signal = new EventEmitter();
-  const abort = () => {
-    signal.emit('abort');
+const polyfillAbortController = () => {
+  const emitter = new EventEmitter();
+  const signal = {
+    emitter,
+    onabort: null,
+    aborted: false,
+    reason: undefined,
+    removeEventListener(name, callback) {
+      emitter.removeListener(name, callback);
+    },
+    addEventListener(name, callback) {
+      emitter.on(name, callback);
+    },
   };
-  return { abort, signal };
+  return {
+    signal,
+    abort(reason) {
+      if (signal.aborted) return;
+      signal.aborted = true;
+      signal.reason = reason ? reason : new Error('AbortError');
+      const event = { type: 'abort', target: signal };
+      if (signal.onabort) signal.onabort(event);
+      emitter.emit(event.type, event);
+    },
+  };
 };
+
+const nativeAbortController = () => new AbortController();
+
+const createAbortController = global.AbortController
+  ? nativeAbortController
+  : polyfillAbortController;
 
 const timeout = (msec, signal = null) =>
   new Promise((resolve, reject) => {
@@ -16,7 +41,7 @@ const timeout = (msec, signal = null) =>
       reject(new Error('Timeout reached'));
     }, msec);
     if (!signal) return;
-    signal.on('abort', () => {
+    signal.addEventListener('abort', () => {
       clearTimeout(timer);
       reject(new Error('Timeout aborted'));
     });
@@ -26,7 +51,7 @@ const delay = (msec, signal = null) =>
   new Promise((resolve, reject) => {
     const timer = setTimeout(resolve, msec);
     if (!signal) return;
-    signal.on('abort', () => {
+    signal.addEventListener('abort', () => {
       clearTimeout(timer);
       reject(new Error('Delay aborted'));
     });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
