### PR TITLE
Make `ensireDirectory` atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Make `ensureDirectory` atomic
+
 ## [3.11.0][] - 2023-07-22
 
 - New utilities: `serializeArguments`, `httpApiCall`, `trimLines`

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -10,13 +10,7 @@ const directoryExists = async (path) => {
 };
 
 const ensureDirectory = async (path) => {
-  return fsp.mkdir(path).then(
-    () => true,
-    (err) => {
-      if (err.code === 'EEXIST') return true;
-      return false;
-    }
-  );
+  return fsp.mkdir(path).then(() => true, (err) => err.code === 'EEXIST');
 };
 
 module.exports = {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -10,9 +10,13 @@ const directoryExists = async (path) => {
 };
 
 const ensureDirectory = async (path) => {
-  const alreadyExists = await directoryExists(path);
-  if (alreadyExists) return true;
-  return fsp.mkdir(path).then(...toBool);
+  return fsp.mkdir(path).then(
+    () => true,
+    (err) => {
+      if (err.code === 'EEXIST') return true;
+      return false;
+    }
+  );
 };
 
 module.exports = {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fsp = require('node:fs').promises;
-const { toBool } = require('./async.js');
 
 const directoryExists = async (path) => {
   const stats = await fsp.stat(path).catch(() => null);
@@ -10,7 +9,10 @@ const directoryExists = async (path) => {
 };
 
 const ensureDirectory = async (path) => {
-  return fsp.mkdir(path).then(() => true, (err) => err.code === 'EEXIST');
+  return fsp.mkdir(path).then(
+    () => true,
+    (err) => err.code === 'EEXIST',
+  );
 };
 
 module.exports = {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

Hey there, continuation of the twitter thread: https://twitter.com/_sergey_zelenov/status/1683747118740111360

Make `ensureDirectory` atomic (i.e. create folder and catch potential `EEXIST` error on the `.mkdir`). That way we are certain that no interference happen. 

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
