### PR TITLE
Fix: capture Pool items synchronously

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { isPromise } = require('node:util/types');
-
 class Pool {
   constructor(options = {}) {
     this.items = [];
@@ -48,7 +46,7 @@ class Pool {
   async capture() {
     let item = this.next();
     if (!item) return null;
-    if (isPromise(item)) item = await item;
+    if (item instanceof Promise) item = await item;
     const index = this.items.indexOf(item);
     this.free[index] = false;
     this.available--;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isPromise } = require('node:util/types');
+
 class Pool {
   constructor(options = {}) {
     this.items = [];
@@ -11,7 +13,7 @@ class Pool {
     this.available = 0;
   }
 
-  async next() {
+  next() {
     if (this.size === 0) return null;
     if (this.available === 0) {
       return new Promise((resolve, reject) => {
@@ -44,8 +46,9 @@ class Pool {
   }
 
   async capture() {
-    const item = await this.next();
+    let item = this.next();
     if (!item) return null;
+    if (isPromise(item)) item = await item;
     const index = this.items.indexOf(item);
     this.free[index] = false;
     this.available--;

--- a/metautil.d.ts
+++ b/metautil.d.ts
@@ -167,7 +167,7 @@ export class Pool {
   size: number;
   available: number;
   timeout: number;
-  next(): Promise<unknown>;
+  next(): unknown | Promise<unknown>;
   add(item: unknown): void;
   capture(): Promise<unknown>;
   release(item: unknown): void;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings


Fixes the issue ([stackblitz](https://stackblitz.com/edit/stackblitz-starters-tfvkfa?file=index.js)) if you try to capture items synchronously.

Code to reproduce:
```JS
const metautil = require('metautil');

(async () => {
  const pool = new metautil.Pool({ timeout: 10000 });

  for (let i = 1; i <= 4; i++) pool.add(i);

  for (let i = 1; i <= 5; i++) {
    pool.capture().then((item) => {
      console.log(item);
    });
  }
})();
```
Result:
```
❯ node index.js
1
2
3
4
1
```
Second `1` shouldn't be printed in this case, because it was never released

