### PR TITLE
Fix Pool async capture after sync exhaustion

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -15,7 +15,13 @@ class Pool {
     if (this.size === 0) return null;
     if (this.available === 0) {
       return new Promise((resolve, reject) => {
-        const waiting = { resolve, timer: null };
+        const waiting = {
+          resolve: (item) => {
+            if (exclusive) this.#capture(item);
+            resolve(item);
+          },
+          timer: null,
+        };
         waiting.timer = setTimeout(() => {
           waiting.resolve = null;
           this.queue.shift();
@@ -32,11 +38,7 @@ class Pool {
       this.current++;
       if (this.current === this.size) this.current = 0;
     } while (!item || !free);
-    if (exclusive) {
-      const index = this.items.indexOf(item);
-      this.free[index] = false;
-      this.available--;
-    }
+    if (exclusive) this.#capture(item);
     return item;
   }
 
@@ -70,6 +72,12 @@ class Pool {
     const index = this.items.indexOf(item);
     if (index < 0) return false;
     return this.free[index];
+  }
+
+  #capture(item) {
+    const index = this.items.indexOf(item);
+    this.free[index] = false;
+    this.available--;
   }
 }
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -154,7 +154,7 @@ metatests.test('Pool: sync capture timeout', (test) => {
   });
 });
 
-metatests.test('Pool: async capture after sync exhaustion', async (test) => {
+metatests.test('Pool: capture from the queue', async (test) => {
   const pool = new metautil.Pool({ timeout: 100 });
   const obj1 = { a: 1 };
   pool.add(obj1);

--- a/test/pool.js
+++ b/test/pool.js
@@ -154,6 +154,18 @@ metatests.test('Pool: sync capture timeout', (test) => {
   });
 });
 
+metatests.test('Pool: async capture after sync exhaustion', async (test) => {
+  const pool = new metautil.Pool({ timeout: 100 });
+  const obj1 = { a: 1 };
+  pool.add(obj1);
+  pool.capture(obj1).then((item) => {
+    setTimeout(() => pool.release(item), 1);
+  });
+  await new Promise((r) => setTimeout(r, 0));
+  const item1 = await pool.capture();
+  test.strictEqual(pool.isFree(item1), false);
+});
+
 metatests.test('Pool: prevent infinite loop', async (test) => {
   const pool = new metautil.Pool();
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Fixes the bug that was introdused in #207, and releated to #206.

Code to reprodure:
```JS
const pool = new metautil.Pool({ timeout: 10000 });

for (let i = 1; i <= 4; i++) pool.add(i);

for (let i = 1; i <= 4; i++) {
  pool.capture().then((item) => {
    console.log(item, pool.isFree(item));
    setTimeout(() => pool.release(item), 10);
  });
}

await new Promise((r) => setTimeout(r, 0));

for (let i = 1; i <= 2; i++) {
  pool.capture().then((item) => {
    console.log(item, pool.isFree(item));
  });
}
```

Result:
```
❯ node index.js
1 false
2 false
3 false
4 false
1 true
2 true
```
Items are not captured, if they were taken asynchronously from the queue