### PR TITLE
Remove collector listeners and now only support then (Without then chaining)

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -7,8 +7,6 @@ class Collector {
   count = 0;
   exact = true;
   timeout = 0;
-  #done = null;
-  #error = null;
   #fulfill = null;
   #reject = null;
   #timer = null;
@@ -31,29 +29,19 @@ class Collector {
     this.#timer = setTimeout(handler, msec);
   }
 
-  on(name, callback) {
-    if (name === 'done') this.#done = callback;
-    else if (name === 'error') this.#error = callback;
-    if (this.done) {
-      if (name === 'error' && this.#cause) callback(this.#cause);
-      else if (name === 'done') callback(this.data);
-    }
-  }
-
   set(key, value) {
     if (this.done) return;
-    const has = this.data[key] !== undefined;
     const expected = this.keys.includes(key);
     if (!expected && this.exact) {
       this.fail(new Error('Unexpected key: ' + key));
       return;
     }
+    const has = this.data[key] !== undefined;
     if (!has && expected) this.count++;
     this.data[key] = value;
     if (this.count === this.keys.length) {
       this.done = true;
       this.#timeout(0);
-      if (this.#done) this.#done(this.data);
       if (this.#fulfill) this.#fulfill(this.data);
     }
   }
@@ -74,10 +62,7 @@ class Collector {
 
   collect(sources) {
     for (const [key, collector] of Object.entries(sources)) {
-      collector.then(
-        (data) => this.set(key, data),
-        (err) => this.fail(err),
-      );
+      collector.then((data) => void this.set(key, data), this.fail);
     }
   }
 
@@ -86,7 +71,6 @@ class Collector {
     this.#timeout(0);
     const err = error || new Error('Collector cancelled');
     this.#cause = err;
-    if (this.#error) this.#error(err);
     if (this.#reject) this.#reject(err);
   }
 

--- a/metautil.d.ts
+++ b/metautil.d.ts
@@ -241,7 +241,6 @@ export class Collector {
   exact: boolean;
   timeout: number;
   constructor(keys: Array<string>, options?: CollectorOptions);
-  on(name: string, callback: Function): void;
   set(key: string, value: unknown): void;
   wait(key: string, fn: AsyncFunction, ...args: Array<unknown>): void;
   take(key: string, fn: Function, ...args: Array<unknown>): void;

--- a/test/collector.js
+++ b/test/collector.js
@@ -30,6 +30,13 @@ metatests.test('Collector: exact', async (test) => {
     dc.set('wrongKey', 'someVal');
   }, 100);
 
+  dc.then(
+    () => {},
+    (error) => {
+      test.strictSame(error.message, 'Unexpected key: wrongKey');
+    },
+  );
+
   try {
     await dc;
   } catch (error) {

--- a/test/collector.js
+++ b/test/collector.js
@@ -12,11 +12,12 @@ metatests.test('Collector: keys', async (test) => {
     dc.set('key2', 2);
   }, 100);
 
-  dc.on('done', (result) => {
+  dc.then((result) => {
     test.strictSame(result, expectedResult);
   });
 
   const result = await dc;
+
   test.strictSame(result, expectedResult);
   test.end();
 });
@@ -28,10 +29,6 @@ metatests.test('Collector: exact', async (test) => {
     dc.set('key1', 1);
     dc.set('wrongKey', 'someVal');
   }, 100);
-
-  dc.on('fail', (error) => {
-    test.strictSame(error.message, 'Unexpected key: wrongKey');
-  });
 
   try {
     await dc;
@@ -169,7 +166,7 @@ metatests.test('Collector: after done', async (test) => {
   dc.set('key1', 1);
   dc.set('key2', 2);
 
-  dc.on('done', (result) => {
+  dc.then((result) => {
     test.strictSame(result, expectedResult);
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
