### PR TITLE
Fix order and duplication of listeners in once/on

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -75,8 +75,6 @@ class EventIterable {
 
 class Emitter {
   #events = new Map();
-  #onceWrappers = new Map();
-  #onceToRemove = [];
   #maxListeners = 10;
 
   constructor(options = {}) {
@@ -84,34 +82,39 @@ class Emitter {
   }
 
   emit(eventName, value) {
-    const listeners = this.#events.get(eventName) || [];
-    if (listeners.length === 0) {
+    const event = this.#events.get(eventName);
+    if (!event) {
       if (eventName !== 'error') return Promise.resolve();
       throw new Error('Unhandled error');
     }
-
-    const promises = listeners.map(async (fn) => fn(value));
-
-    if (this.#onceToRemove.length) {
-      for (const removeData of this.#onceToRemove) {
-        this.off(...removeData);
+    const promises = event.on.map(async (fn) => fn(value));
+    if (event.once.length > 0) {
+      const on = new Array(event.on.length);
+      let index = 0;
+      for (let i = 0, len = event.on.length; i < len; i++) {
+        const listener = event.on[i];
+        if (!event.once.includes(listener)) on[index++] = listener;
       }
-      this.#onceToRemove = [];
+      on.length = index;
+      if (index > 0) this.#events.set(eventName, { on, once: [] });
+      else this.#events.delete(eventName);
     }
-
     return Promise.all(promises).then(() => undefined);
   }
 
-  on(eventName, listener) {
-    this.#checkDuplicateListener(eventName, listener);
-    let listeners = this.#events.get(eventName);
-    if (listeners) {
-      listeners.push(listener);
+  #addListener(eventName, listener, once) {
+    let event = this.#events.get(eventName);
+    if (!event) {
+      event = { on: [listener], once: once ? [listener] : [] };
+      this.#events.set(eventName, event);
     } else {
-      listeners = [listener];
-      this.#events.set(eventName, listeners);
+      if (event.on.includes(listener)) {
+        throw new Error('Duplicate listeners detected');
+      }
+      event.on.push(listener);
+      if (once) event.once.push(listener);
     }
-    if (listeners.length > this.#maxListeners) {
+    if (event.on.length > this.#maxListeners) {
       throw new Error(
         `MaxListenersExceededWarning: Possible memory leak. ` +
           `Current maxListeners is ${this.#maxListeners}.`,
@@ -119,37 +122,22 @@ class Emitter {
     }
   }
 
+  on(eventName, listener) {
+    this.#addListener(eventName, listener, false);
+  }
+
   once(eventName, listener) {
-    this.#checkDuplicateListener(eventName, listener);
-    const wrapper = (...args) => {
-      const result = listener(...args);
-      this.#onceToRemove.push([eventName, listener]);
-      return result;
-    };
-
-    this.on(eventName, wrapper);
-
-    let onceWrappersMap = this.#onceWrappers.get(eventName);
-    if (!onceWrappersMap) {
-      onceWrappersMap = new Map();
-      this.#onceWrappers.set(eventName, onceWrappersMap);
-    }
-    onceWrappersMap.set(listener, wrapper);
+    this.#addListener(eventName, listener, true);
   }
 
   off(eventName, listener) {
-    if (!listener) return void this.clear(eventName);
-
-    const listenerWrapper = this.#onceWrappers.get(eventName)?.get(listener);
-    const currentListener = listenerWrapper || listener;
-    const listeners = this.#events.get(eventName) || [];
-    const listenerIndex = listeners.indexOf(currentListener);
-
-    if (listenerIndex > -1) listeners.splice(listenerIndex, 1);
-
-    if (listenerWrapper) {
-      this.#onceWrappers.get(eventName)?.delete(listener);
-    }
+    if (!listener) return void this.#events.delete(eventName);
+    const event = this.#events.get(eventName);
+    if (!event) return;
+    const onIndex = event.on.indexOf(listener);
+    if (onIndex > -1) event.on.splice(onIndex, 1);
+    const onceIndex = event.once.indexOf(listener);
+    if (onceIndex > -1) event.once.splice(onceIndex, 1);
   }
 
   toPromise(eventName) {
@@ -163,36 +151,40 @@ class Emitter {
   }
 
   clear(eventName) {
-    if (!eventName) {
-      this.#events.clear();
-      this.#onceWrappers.clear();
-      return;
-    }
+    if (!eventName) return void this.#events.clear();
     this.#events.delete(eventName);
-    this.#onceWrappers.delete(eventName);
   }
 
   listeners(eventName) {
     if (eventName) {
-      return this.#events.get(eventName) || [];
+      const event = this.#events.get(eventName);
+      return event ? event.on : [];
     }
-    return Array.from(this.#events.values()).flat();
+    const listeners = new Set();
+    for (const event of this.#events.values()) {
+      for (let i = 0, len = event.on.length; i < len; i++) {
+        listeners.add(event.on[i]);
+      }
+    }
+    return Array.from(listeners);
   }
 
   listenerCount(eventName) {
-    const events = this.#events.get(eventName);
-    return events ? events.length : 0;
+    if (eventName) {
+      const event = this.#events.get(eventName);
+      return event ? event.on.length : 0;
+    }
+    const listeners = new Set();
+    for (const event of this.#events.values()) {
+      for (let i = 0, len = event.on.length; i < len; i++) {
+        listeners.add(event.on[i]);
+      }
+    }
+    return listeners.size;
   }
 
   eventNames() {
-    const names = new Set(this.#events.keys());
-    return Array.from(names);
-  }
-
-  #checkDuplicateListener(eventName, listener) {
-    const hasEvent = this.#events.get(eventName)?.includes(listener);
-    const hasWrapper = this.#onceWrappers.get(eventName)?.get(listener);
-    if (hasEvent || hasWrapper) throw new Error('Duplicate listeners detected');
+    return Array.from(this.#events.keys());
   }
 }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -86,10 +86,10 @@ class Emitter {
   emit(eventName, value) {
     const listeners = this.#events.get(eventName) || [];
     if (listeners.length === 0) {
-      if (eventName !== 'error') return;
+      if (eventName !== 'error') return Promise.resolve();
       throw new Error('Unhandled error');
     }
-    if (!listeners) return Promise.resolve();
+
     const promises = listeners.map(async (fn) => fn(value));
 
     if (this.#onceToRemove.length) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -192,7 +192,7 @@ class Emitter {
   #checkDuplicateListener(eventName, listener) {
     const hasEvent = this.#events.get(eventName)?.includes(listener);
     if (!hasEvent) return;
-    const hasWrapper this.#onceWrappers.get(eventName)?.get(listener);
+    const hasWrapper = this.#onceWrappers.get(eventName)?.get(listener);
     if (!hasWrapper) return;
     throw new Error('Duplicate listeners detected');
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -75,7 +75,7 @@ class EventIterable {
 
 class Emitter {
   #events = new Map();
-  #onceWrappersMap = new Map();
+  #onceWrappers = new Map();
   #onceToRemove = [];
   #maxListeners = 10;
 
@@ -129,10 +129,10 @@ class Emitter {
 
     this.on(eventName, wrapper);
 
-    let onceWrappersMap = this.#onceWrappersMap.get(eventName);
+    let onceWrappersMap = this.#onceWrappers.get(eventName);
     if (!onceWrappersMap) {
       onceWrappersMap = new Map();
-      this.#onceWrappersMap.set(eventName, onceWrappersMap);
+      this.#onceWrappers.set(eventName, onceWrappersMap);
     }
     onceWrappersMap.set(listener, wrapper);
   }
@@ -140,7 +140,7 @@ class Emitter {
   off(eventName, listener) {
     if (!listener) return void this.clear(eventName);
 
-    const listenerWrapper = this.#onceWrappersMap.get(eventName)?.get(listener);
+    const listenerWrapper = this.#onceWrappers.get(eventName)?.get(listener);
     const currentListener = listenerWrapper || listener;
     const listeners = this.#events.get(eventName) || [];
     const listenerIndex = listeners.indexOf(currentListener);
@@ -148,7 +148,7 @@ class Emitter {
     if (listenerIndex > -1) listeners.splice(listenerIndex, 1);
 
     if (listenerWrapper) {
-      this.#onceWrappersMap.get(eventName)?.delete(listener);
+      this.#onceWrappers.get(eventName)?.delete(listener);
     }
   }
 
@@ -165,11 +165,11 @@ class Emitter {
   clear(eventName) {
     if (!eventName) {
       this.#events.clear();
-      this.#onceWrappersMap.clear();
+      this.#onceWrappers.clear();
       return;
     }
     this.#events.delete(eventName);
-    this.#onceWrappersMap.delete(eventName);
+    this.#onceWrappers.delete(eventName);
   }
 
   listeners(eventName) {
@@ -192,7 +192,7 @@ class Emitter {
   #checkDuplicateListener(eventName, listener) {
     const hasEvent = this.#events.get(eventName)?.includes(listener);
     if (!hasEvent) return;
-    const hasWrapper this.#onceWrappersMap.get(eventName)?.get(listener);
+    const hasWrapper this.#onceWrappers.get(eventName)?.get(listener);
     if (!hasWrapper) return;
     throw new Error('Duplicate listeners detected');
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -191,10 +191,8 @@ class Emitter {
 
   #checkDuplicateListener(eventName, listener) {
     const hasEvent = this.#events.get(eventName)?.includes(listener);
-    if (!hasEvent) return;
     const hasWrapper = this.#onceWrappers.get(eventName)?.get(listener);
-    if (!hasWrapper) return;
-    throw new Error('Duplicate listeners detected');
+    if (hasEvent || hasWrapper) throw new Error('Duplicate listeners detected');
   }
 }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -102,13 +102,13 @@ class Emitter {
     return Promise.all(promises).then(() => undefined);
   }
 
-  on(eventName, currentListener) {
-    this.#checkDuplicateListener(eventName, currentListener);
+  on(eventName, listener) {
+    this.#checkDuplicateListener(eventName, listener);
     let listeners = this.#events.get(eventName);
     if (listeners) {
-      listeners.push(currentListener);
+      listeners.push(listener);
     } else {
-      listeners = [currentListener];
+      listeners = [listener];
       this.#events.set(eventName, listeners);
     }
     if (listeners.length > this.#maxListeners) {
@@ -189,15 +189,13 @@ class Emitter {
     return Array.from(names);
   }
 
-  #checkDuplicateListener = (eventName, listener) => {
-    if (
-      this.#events.get(eventName)?.includes(listener) ||
-      this.#onceWrappersMap.get(eventName)?.get(listener)
-    ) {
-      throw new Error('Duplicate listeners detected');
-    }
-    return true;
-  };
+  #checkDuplicateListener(eventName, listener) {
+    const hasEvent = this.#events.get(eventName)?.includes(listener);
+    if (!hasEvent) return;
+    const hasWrapper this.#onceWrappersMap.get(eventName)?.get(listener);
+    if (!hasWrapper) return;
+    throw new Error('Duplicate listeners detected');
+  }
 }
 
 module.exports = { Emitter };

--- a/lib/events.js
+++ b/lib/events.js
@@ -75,7 +75,8 @@ class EventIterable {
 
 class Emitter {
   #events = new Map();
-  #onceEvents = new Map();
+  #onceWrappersMap = new Map();
+  #onceToRemove = [];
   #maxListeners = 10;
 
   constructor(options = {}) {
@@ -84,27 +85,30 @@ class Emitter {
 
   emit(eventName, value) {
     const listeners = this.#events.get(eventName) || [];
-    const onceListeners = this.#onceEvents.get(eventName) || [];
-    const handlers = listeners.concat(onceListeners);
-    if (handlers.length === 0) {
-      if (eventName !== 'error') return Promise.resolve();
+    if (listeners.length === 0) {
+      if (eventName !== 'error') return;
       throw new Error('Unhandled error');
     }
-    if (!listeners && !onceListeners) return Promise.resolve();
-    const promises = handlers.map(async (fn) => fn(value));
-    this.#onceEvents.delete(eventName);
+    if (!listeners) return Promise.resolve();
+    const promises = listeners.map(async (fn) => fn(value));
+
+    if (this.#onceToRemove.length) {
+      for (const removeData of this.#onceToRemove) {
+        this.off(...removeData);
+      }
+      this.#onceToRemove = [];
+    }
+
     return Promise.all(promises).then(() => undefined);
   }
 
-  on(eventName, listener) {
+  on(eventName, currentListener) {
+    this.#checkDuplicateListener(eventName, currentListener);
     let listeners = this.#events.get(eventName);
     if (listeners) {
-      if (listeners.includes(listener)) {
-        throw new Error('Duplicate listeners detected');
-      }
-      listeners.push(listener);
+      listeners.push(currentListener);
     } else {
-      listeners = [listener];
+      listeners = [currentListener];
       this.#events.set(eventName, listeners);
     }
     if (listeners.length > this.#maxListeners) {
@@ -116,35 +120,36 @@ class Emitter {
   }
 
   once(eventName, listener) {
-    let listeners = this.#onceEvents.get(eventName);
-    if (listeners) {
-      if (listeners.includes(listener)) {
-        throw new Error('Duplicate listeners detected');
-      }
-      listeners.push(listener);
-    } else {
-      listeners = [listener];
-      this.#onceEvents.set(eventName, listeners);
+    this.#checkDuplicateListener(eventName, listener);
+    const wrapper = (...args) => {
+      const result = listener(...args);
+      this.#onceToRemove.push([eventName, listener]);
+      return result;
+    };
+
+    this.on(eventName, wrapper);
+
+    let onceWrappersMap = this.#onceWrappersMap.get(eventName);
+    if (!onceWrappersMap) {
+      onceWrappersMap = new Map();
+      this.#onceWrappersMap.set(eventName, onceWrappersMap);
     }
-    if (listeners.length > this.#maxListeners) {
-      throw new Error(
-        `MaxListenersExceededWarning: Possible memory leak. ` +
-          `Current maxListeners is ${this.#maxListeners}.`,
-      );
-    }
+    onceWrappersMap.set(listener, wrapper);
   }
 
   off(eventName, listener) {
     if (!listener) return void this.clear(eventName);
 
+    const listenerWrapper = this.#onceWrappersMap.get(eventName)?.get(listener);
+    const currentListener = listenerWrapper || listener;
     const listeners = this.#events.get(eventName) || [];
-    const onceListeners = this.#onceEvents.get(eventName) || [];
+    const listenerIndex = listeners.indexOf(currentListener);
 
-    const listenerIndex = listeners.indexOf(listener);
     if (listenerIndex > -1) listeners.splice(listenerIndex, 1);
 
-    const onceIndex = onceListeners.indexOf(listener);
-    if (onceIndex > -1) onceListeners.splice(onceIndex, 1);
+    if (listenerWrapper) {
+      this.#onceWrappersMap.get(eventName)?.delete(listener);
+    }
   }
 
   toPromise(eventName) {
@@ -160,37 +165,39 @@ class Emitter {
   clear(eventName) {
     if (!eventName) {
       this.#events.clear();
-      this.#onceEvents.clear();
+      this.#onceWrappersMap.clear();
       return;
     }
     this.#events.delete(eventName);
-    this.#onceEvents.delete(eventName);
+    this.#onceWrappersMap.delete(eventName);
   }
 
   listeners(eventName) {
     if (eventName) {
-      const events = this.#events.get(eventName) || [];
-      const onceEvents = this.#onceEvents.get(eventName) || [];
-      return events.concat(onceEvents);
+      return this.#events.get(eventName) || [];
     }
-    const events = Array.from(this.#events.values()).flat();
-    const onceEvents = Array.from(this.#onceEvents.values()).flat();
-    return events.concat(onceEvents);
+    return Array.from(this.#events.values()).flat();
   }
 
   listenerCount(eventName) {
     const events = this.#events.get(eventName);
-    const eventCount = events ? events.length : 0;
-    const onceEvents = this.#onceEvents.get(eventName);
-    const onceCount = onceEvents ? onceEvents.length : 0;
-    return eventCount + onceCount;
+    return events ? events.length : 0;
   }
 
   eventNames() {
     const names = new Set(this.#events.keys());
-    for (const key of this.#onceEvents.keys()) names.add(key);
     return Array.from(names);
   }
+
+  #checkDuplicateListener = (eventName, listener) => {
+    if (
+      this.#events.get(eventName)?.includes(listener) ||
+      this.#onceWrappersMap.get(eventName)?.get(listener)
+    ) {
+      throw new Error('Duplicate listeners detected');
+    }
+    return true;
+  };
 }
 
 module.exports = { Emitter };

--- a/test/events.js
+++ b/test/events.js
@@ -285,8 +285,8 @@ test('Emitter calls listeners order', async () => {
 
   await ee.emit('eventM');
 
-  ee.on('eventM', e5);
-  ee.once('eventM', e2);
+  ee.once('eventM', e5);
+  ee.on('eventM', e2);
 
   await ee.emit('eventM');
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

## Context

This PR provides an alternative implementation that ensures full backward compatibility with the native `EventEmitter` behavior. It addresses two main issues:

1. Listeners are invoked in the exact order they were added, regardless of using `on` or `once`.
2. Duplicate listeners are prevented across all combinations of `on` and `once`.

These changes improve predictability and alignment with established event handling patterns.

Additionally, the fix improves performance in the most performance-critical path — the `emit` function — by simplifying internal listener checks.

## Solution

The issue is resolved by using a single unified listener queue instead of maintaining separate ones for `on` and `once`. This ensures correct execution order based on the registration sequence.

For `once` listeners, a self-unsubscribing wrapper is used, which removes itself after invoking the original listener.

To handle duplicates and maintain consistency, a mapping between the original listener and its wrapper is introduced. This mapping allows:

- Detection of duplicates whether a raw listener or a wrapper is registered,
- Correct removal of `once` wrappers even when `off()` is called with the original listener reference.

