### PR TITLE
feat: Wrapless approach with Set to store once.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -75,6 +75,7 @@ class EventIterable {
 
 class Emitter {
   #events = new Map();
+  #onceEvents = new Map();
   #maxListeners = 10;
 
   constructor(options = {}) {
@@ -82,62 +83,58 @@ class Emitter {
   }
 
   emit(eventName, value) {
-    const event = this.#events.get(eventName);
-    if (!event) {
+    const events = this.#events.get(eventName) || [];
+    if (events.length === 0) {
       if (eventName !== 'error') return Promise.resolve();
       throw new Error('Unhandled error');
     }
-    const promises = event.on.map(async (fn) => fn(value));
-    if (event.once.length > 0) {
-      const on = new Array(event.on.length);
-      let index = 0;
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        const listener = event.on[i];
-        if (!event.once.includes(listener)) on[index++] = listener;
+
+    const promises = events.map(async (fn) => fn(value));
+
+    const onceEvents = this.#onceEvents.get(eventName);
+    if (onceEvents?.size) {
+      for (const onceEvent of onceEvents) {
+        this.off(eventName, onceEvent);
       }
-      on.length = index;
-      if (index > 0) this.#events.set(eventName, { on, once: [] });
-      else this.#events.delete(eventName);
     }
+
     return Promise.all(promises).then(() => undefined);
   }
 
-  #addListener(eventName, listener, once) {
-    let event = this.#events.get(eventName);
-    if (!event) {
-      event = { on: [listener], once: once ? [listener] : [] };
-      this.#events.set(eventName, event);
-    } else {
-      if (event.on.includes(listener)) {
-        throw new Error('Duplicate listeners detected');
-      }
-      event.on.push(listener);
-      if (once) event.once.push(listener);
+  on(eventName, listener) {
+    if (this.#events.get(eventName)?.includes(listener)) {
+      throw new Error('Duplicate listeners detected');
     }
-    if (event.on.length > this.#maxListeners) {
+
+    const events = this.#events.get(eventName) || [];
+    if (events.length >= this.#maxListeners) {
       throw new Error(
         `MaxListenersExceededWarning: Possible memory leak. ` +
           `Current maxListeners is ${this.#maxListeners}.`,
       );
     }
-  }
 
-  on(eventName, listener) {
-    this.#addListener(eventName, listener, false);
+    events.push(listener);
+    this.#events.set(eventName, events);
   }
 
   once(eventName, listener) {
-    this.#addListener(eventName, listener, true);
+    this.on(eventName, listener);
+
+    const onceEvents = this.#onceEvents.get(eventName) || new Set();
+    onceEvents.add(listener);
+    this.#onceEvents.set(eventName, onceEvents);
   }
 
   off(eventName, listener) {
-    if (!listener) return void this.#events.delete(eventName);
-    const event = this.#events.get(eventName);
-    if (!event) return;
-    const onIndex = event.on.indexOf(listener);
-    if (onIndex > -1) event.on.splice(onIndex, 1);
-    const onceIndex = event.once.indexOf(listener);
-    if (onceIndex > -1) event.once.splice(onceIndex, 1);
+    if (!listener) return void this.clear(eventName);
+
+    const events = this.#events.get(eventName) || [];
+    const listenerIndex = events.indexOf(listener);
+    if (listenerIndex > -1) events.splice(listenerIndex, 1);
+
+    const onceEvents = this.#onceEvents.get(eventName);
+    if (onceEvents?.has(listener)) onceEvents.delete(listener);
   }
 
   toPromise(eventName) {
@@ -151,36 +148,25 @@ class Emitter {
   }
 
   clear(eventName) {
-    if (!eventName) return void this.#events.clear();
+    if (!eventName) {
+      this.#events.clear();
+      this.#onceEvents.clear();
+      return;
+    }
     this.#events.delete(eventName);
+    this.#onceEvents.delete(eventName);
   }
 
   listeners(eventName) {
     if (eventName) {
-      const event = this.#events.get(eventName);
-      return event ? event.on : [];
+      return this.#events.get(eventName) || [];
     }
-    const listeners = new Set();
-    for (const event of this.#events.values()) {
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        listeners.add(event.on[i]);
-      }
-    }
-    return Array.from(listeners);
+    return Array.from(this.#events.values()).flat();
   }
 
   listenerCount(eventName) {
-    if (eventName) {
-      const event = this.#events.get(eventName);
-      return event ? event.on.length : 0;
-    }
-    const listeners = new Set();
-    for (const event of this.#events.values()) {
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        listeners.add(event.on[i]);
-      }
-    }
-    return listeners.size;
+    const events = this.#events.get(eventName);
+    return events ? events.length : 0;
   }
 
   eventNames() {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

This update is based on @tshemsedinov's recomendation to make EventEmitter without wrapers and @mykhailo-vaskivnyuk's suggestion use Set for store 'once' events, which he uses in his pr #291. Additionaly I added my vission on how to reduce the code and avoid any checks during iteration in emit function to make it as fast as posible.