### PR TITLE
feat: use nextListeners array

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -81,40 +81,37 @@ class Emitter {
     this.#maxListeners = options.maxListeners ?? 10;
   }
 
-  emit(eventName, value) {
+  async emit(eventName, value) {
     const event = this.#events.get(eventName);
     if (!event) {
-      if (eventName !== 'error') return Promise.resolve();
+      if (eventName !== 'error') return;
       throw new Error('Unhandled error');
     }
-    const promises = event.on.map(async (fn) => fn(value));
-    if (event.once.length > 0) {
-      const on = new Array(event.on.length);
-      let index = 0;
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        const listener = event.on[i];
-        if (!event.once.includes(listener)) on[index++] = listener;
-      }
-      on.length = index;
-      if (index > 0) this.#events.set(eventName, { on, once: [] });
-      else this.#events.delete(eventName);
+
+    const { listeners, nextListeners } = event;
+    if (listeners.length !== nextListeners.length) {
+      event.listeners = [...nextListeners];
     }
-    return Promise.all(promises).then(() => undefined);
+
+    const promises = listeners.map((fn) => fn(value));
+    await Promise.all(promises);
   }
 
   #addListener(eventName, listener, once) {
-    let event = this.#events.get(eventName);
-    if (!event) {
-      event = { on: [listener], once: once ? [listener] : [] };
+    const event = this.#events.get(eventName) || {};
+
+    if (!event.listeners) {
+      event.listeners = [];
+      event.nextListeners = [];
       this.#events.set(eventName, event);
-    } else {
-      if (event.on.includes(listener)) {
-        throw new Error('Duplicate listeners detected');
-      }
-      event.on.push(listener);
-      if (once) event.once.push(listener);
+    } else if (event.listeners.includes(listener)) {
+      throw new Error('Duplicate listeners detected');
     }
-    if (event.on.length > this.#maxListeners) {
+
+    event.listeners.push(listener);
+    if (!once) event.nextListeners.push(listener);
+
+    if (event.listeners.length > this.#maxListeners) {
       throw new Error(
         `MaxListenersExceededWarning: Possible memory leak. ` +
           `Current maxListeners is ${this.#maxListeners}.`,
@@ -131,13 +128,11 @@ class Emitter {
   }
 
   off(eventName, listener) {
-    if (!listener) return void this.#events.delete(eventName);
+    if (!listener) return void this.clear(eventName);
     const event = this.#events.get(eventName);
     if (!event) return;
-    const onIndex = event.on.indexOf(listener);
-    if (onIndex > -1) event.on.splice(onIndex, 1);
-    const onceIndex = event.once.indexOf(listener);
-    if (onceIndex > -1) event.once.splice(onceIndex, 1);
+    event.listeners = event.listeners.filter((fn) => fn !== listener);
+    event.nextListeners = event.nextListeners.filter((fn) => fn !== listener);
   }
 
   toPromise(eventName) {
@@ -151,36 +146,21 @@ class Emitter {
   }
 
   clear(eventName) {
-    if (!eventName) return void this.#events.clear();
-    this.#events.delete(eventName);
+    if (!eventName) this.#events.clear();
+    else this.#events.delete(eventName);
   }
 
   listeners(eventName) {
     if (eventName) {
       const event = this.#events.get(eventName);
-      return event ? event.on : [];
+      return event ? event.listeners : [];
     }
-    const listeners = new Set();
-    for (const event of this.#events.values()) {
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        listeners.add(event.on[i]);
-      }
-    }
-    return Array.from(listeners);
+    const events = Array.from(this.#events.values());
+    return events.map((event) => event.listeners).flat();
   }
 
   listenerCount(eventName) {
-    if (eventName) {
-      const event = this.#events.get(eventName);
-      return event ? event.on.length : 0;
-    }
-    const listeners = new Set();
-    for (const event of this.#events.values()) {
-      for (let i = 0, len = event.on.length; i < len; i++) {
-        listeners.add(event.on[i]);
-      }
-    }
-    return listeners.size;
+    return this.listeners(eventName).length;
   }
 
   eventNames() {

--- a/test/events.js
+++ b/test/events.js
@@ -292,3 +292,20 @@ test('Emitter calls listeners order', async () => {
 
   assert.deepStrictEqual(results, [1, 3, 4, 6, 1, 3, 5, 2]);
 });
+
+test('Emitter.off do not change event listeners array', async () => {
+  const ee = new metautil.Emitter();
+  let count = 0;
+  const eventName = 'eventN';
+
+  const listener = () => {
+    count++;
+    ee.off(eventName, listener);
+  };
+
+  ee.on(eventName, listener);
+  ee.on(eventName, () => count++);
+
+  await ee.emit(eventName, eventName);
+  assert.strictEqual(count, 2);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

The idea is to move nextListeners to listeners if arrays have different length:
->on
nextListeners [1]
listeners          [1]

->on
nextListeners [1]
listeners          [1, 2-once]

->before emit
nextListeners [1, 3, 4]
listeners          [1, 2-once, 3, 4, 5-once]

->after emit
nextListeners [1, 3, 4]
listeners          [1, 3, 4]

