### PR TITLE
feat: add flattenBySeparator and unflattenBySeparator for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+- Added flattenBySeparator: flattens nested objects and arrays using a custom
+  separator
+- Added unflattenBySeparator: reconstructs nested objects from flattened keys
+
 ## [5.4.0][] - 2025-09-15
 
 - Added firstKey: returns the first key in an object that starts with a letter

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -111,6 +111,75 @@ const firstKey = (obj) => Object.keys(obj).find(isFirstLetter);
 
 const isInstanceOf = (obj, constrName) => obj?.constructor?.name === constrName;
 
+const flattenBySeparator = (source, separator, prefix = '') => {
+  const result = {};
+  const parentKey = prefix ? prefix + separator : '';
+
+  for (const [key, value] of Object.entries(source)) {
+    const newKey = parentKey + key;
+
+    if (value === null || value === undefined) {
+      result[newKey] = value;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      for (let i = 0; i < value.length; i++) {
+        const item = value[i];
+        const arrayKey = newKey + separator + i;
+        if (item !== null && typeof item === 'object') {
+          const nested = flattenBySeparator({ [i]: item }, separator, newKey);
+          Object.assign(result, nested);
+        } else {
+          result[arrayKey] = item;
+        }
+      }
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      const nested = flattenBySeparator(value, separator, newKey);
+      if (Object.keys(nested).length === 0) continue;
+      Object.assign(result, nested);
+      continue;
+    }
+
+    result[newKey] = value;
+  }
+
+  return result;
+};
+
+const unflattenBySeparator = (source, separator) => {
+  const result = {};
+
+  for (const [path, value] of Object.entries(source)) {
+    const keys = path.split(separator);
+    let current = result;
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const isLast = i === keys.length - 1;
+
+      if (isLast) {
+        current[key] = value;
+      } else {
+        const nextKey = keys[i + 1];
+        const isNextNumeric = /^\d+$/.test(nextKey);
+
+        if (!current[key]) {
+          current[key] = isNextNumeric ? [] : {};
+        }
+
+        current = current[key];
+      }
+    }
+  }
+
+  return result;
+};
+
 module.exports = {
   makePrivate,
   protect,
@@ -123,4 +192,6 @@ module.exports = {
   serializeArguments,
   firstKey,
   isInstanceOf,
+  flattenBySeparator,
+  unflattenBySeparator,
 };

--- a/metautil.d.ts
+++ b/metautil.d.ts
@@ -154,6 +154,15 @@ export function namespaceByPath(
 export function serializeArguments(fields: Strings, args: Dictionary): string;
 export function firstKey(obj: Dictionary): string | undefined;
 export function isInstanceOf(obj: unknown, constrName: string): boolean;
+export function flattenBySeparator(
+  source: object,
+  separator: string,
+  prefix?: string,
+): Dictionary;
+export function unflattenBySeparator(
+  source: Dictionary,
+  separator: string,
+): object;
 
 // Submodule: pool
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -276,3 +276,206 @@ test('Object: isInstanceOf', () => {
   assert.strictEqual(metautil.isInstanceOf(regex, 'RegExp'), true);
   assert.strictEqual(metautil.isInstanceOf(regex, 'Object'), false);
 });
+
+test('Object: flattenBySeparator with separator', () => {
+  const obj = {
+    levelOne: {
+      levelTwo: {
+        prop: 'test',
+      },
+    },
+    simpleProp: 'test 2',
+    array: [1, 2],
+  };
+
+  const result = metautil.flattenBySeparator(obj, '$$');
+
+  const expected = {
+    levelOne$$levelTwo$$prop: 'test',
+    simpleProp: 'test 2',
+    array$$0: 1,
+    array$$1: 2,
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: flattenBySeparator with parent namespace', () => {
+  const obj = {
+    levelOne: {
+      levelTwo: {
+        prop: 'test',
+      },
+    },
+    simpleProp: 'test 2',
+  };
+
+  const result = metautil.flattenBySeparator(obj, '$$', 'parentNs');
+
+  const expected = {
+    parentNs$$levelOne$$levelTwo$$prop: 'test',
+    parentNs$$simpleProp: 'test 2',
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: flattenBySeparator with dot separator', () => {
+  const obj = {
+    level: {
+      nested: {
+        value: 123,
+      },
+    },
+    other: 'string',
+  };
+
+  const result = metautil.flattenBySeparator(obj, '.');
+
+  const expected = {
+    'level.nested.value': 123,
+    other: 'string',
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: flattenBySeparator with null and undefined', () => {
+  const obj = {
+    nullValue: null,
+    undefinedValue: undefined,
+    nested: {
+      nullInside: null,
+    },
+  };
+
+  const result = metautil.flattenBySeparator(obj, '.');
+
+  const expected = {
+    nullValue: null,
+    undefinedValue: undefined,
+    'nested.nullInside': null,
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: flattenBySeparator with empty object and array', () => {
+  const obj = {
+    emptyObj: {},
+    emptyArr: [],
+    nested: {
+      empty: {},
+    },
+  };
+
+  const result = metautil.flattenBySeparator(obj, '.');
+
+  const expected = {};
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: unflattenBySeparator with separator', () => {
+  const flat = {
+    levelOne$$levelTwo$$prop: 'test',
+    simpleProp: 'test 2',
+    array$$0: 1,
+    array$$1: 2,
+  };
+
+  const result = metautil.unflattenBySeparator(flat, '$$');
+
+  const expected = {
+    levelOne: {
+      levelTwo: {
+        prop: 'test',
+      },
+    },
+    simpleProp: 'test 2',
+    array: [1, 2],
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: unflattenBySeparator with dot separator', () => {
+  const flat = {
+    'level.nested.value': 123,
+    other: 'string',
+  };
+
+  const result = metautil.unflattenBySeparator(flat, '.');
+
+  const expected = {
+    level: {
+      nested: {
+        value: 123,
+      },
+    },
+    other: 'string',
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: unflattenBySeparator with numeric keys creates arrays', () => {
+  const flat = {
+    'items.0': 'first',
+    'items.1': 'second',
+    'items.2': 'third',
+  };
+
+  const result = metautil.unflattenBySeparator(flat, '.');
+
+  const expected = {
+    items: ['first', 'second', 'third'],
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: unflattenBySeparator with mixed paths', () => {
+  const flat = {
+    'user.name': 'John',
+    'user.age': 30,
+    'user.addresses.0.city': 'New York',
+    'user.addresses.0.zip': '10001',
+    'user.addresses.1.city': 'Boston',
+    'user.addresses.1.zip': '02101',
+  };
+
+  const result = metautil.unflattenBySeparator(flat, '.');
+
+  const expected = {
+    user: {
+      name: 'John',
+      age: 30,
+      addresses: [
+        { city: 'New York', zip: '10001' },
+        { city: 'Boston', zip: '02101' },
+      ],
+    },
+  };
+
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Object: flatten and unflatten roundtrip', () => {
+  const original = {
+    level1: {
+      level2: {
+        level3: {
+          value: 'deep',
+        },
+      },
+      array: [1, 2, { nested: true }],
+    },
+    simple: 'value',
+  };
+
+  const flattened = metautil.flattenBySeparator(original, '.');
+  const unflattened = metautil.unflattenBySeparator(flattened, '.');
+
+  assert.deepStrictEqual(unflattened, original);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings

## PR Description: Add flattenBySeparator and unflattenBySeparator for Object Manipulation
### Motivation
Working with internationalization (i18n) resources often involves handling JSON translation files. These resources are frequently stored as plain (flat) JSON objects for ease of management in external translation tools or databases. However, within applications, it is often necessary to work with these resources as nested objects to match the logical structure of the UI or component hierarchy.
This PR introduces two new utility functions to metautil to facilitate this conversion:
- flattenBySeparator: Converts a nested object into a flat dictionary where keys are paths separated by a specified character (e.g., .).
- unflattenBySeparator: Reconstructs a nested object from a flat dictionary using the separator to interpret the keys as paths.
These utilities are particularly useful when:
1. i18n: You need to "unflatten" translation keys (e.g., user.profile.name) into a nested object structure for consumption by libraries like next-i18next or custom localization logic.
2. Configuration: Managing environment variables or flat config files that represent nested application settings.
3. Data Transformation: Handling API responses that use dot-notation for nested fields.