### PR TITLE
Infer Struct field types from literal defaults 

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,45 @@ const size = loaded.map((buffer) => buffer.length).unwrap(0);
 - `firstKey(obj: Dictionary): string | undefined`
 - `isInstanceOf(obj: unknown, constrName: string): boolean`
 
+## Class `Struct`
+
+Typed records with schema inferred from literal defaults.
+
+- `Struct.immutable(className: string, defaults: object): StructClass`
+- `Struct.mutable(className: string, defaults: object): StructClass`
+
+Default literals define field types:
+
+- `undefined` → schema `unknown`, accepts any value, defaults to `undefined`
+- `null` → schema `ref`, accepts null, objects, and functions, defaults to `null`
+- `[]` → schema `array`, accepts arrays, fresh copy per instance
+- `{}` → schema `object`, accepts plain objects, fresh copy per instance
+- primitive → schema `typeof`, accepts exact primitive type, literal default value
+
+Generated class:
+
+- `constructor(data?: object)`
+- `static create(data?: object): StructRecord`
+- `static fields: Array<string>`
+- `static schema: object`
+- `static mutable: boolean`
+- `update(updates: object): this` (mutable only)
+- `fork(updates?: object): StructRecord`
+- `branch(updates?: object): StructRecord`
+- `toObject(): object`
+
+```js
+const City = metautil.Struct.immutable('City', { name: 'Unknown' });
+const rome = new City({ name: 'Rome' });
+
+const User = metautil.Struct.mutable('User', {
+  id: 0,
+  name: 'Anonymous',
+  roles: [],
+});
+const marcus = User.create({ id: 1, name: 'Marcus' });
+```
+
 ## Class Pool
 
 - `constructor(options: PoolOptions)`

--- a/lib/struct.js
+++ b/lib/struct.js
@@ -1,9 +1,25 @@
 'use strict';
 
 const typeOf = (value) => {
+  if (value === undefined) return 'unknown';
+  if (value === null) return 'ref';
   if (Array.isArray(value)) return 'array';
-  if (value === null) return 'null';
   return typeof value;
+};
+
+const matchesType = (expected, value) => {
+  if (expected === 'unknown') return true;
+  if (expected === 'ref') {
+    const type = typeof value;
+    return type === 'object' || type === 'function';
+  }
+  return typeOf(value) === expected;
+};
+
+const createDefault = (type, value) => {
+  if (type === 'array') return value.slice();
+  if (type === 'object') return { ...value };
+  return value;
 };
 
 class Struct {
@@ -29,11 +45,10 @@ class Struct {
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
         const expected = schema[key];
-        if (!expected) {
-          throw new TypeError(`Unknown field "${key}"`);
-        }
-        const actual = typeOf(data[key]);
-        if (actual !== expected) {
+        if (!expected) throw new TypeError(`Unknown field "${key}"`);
+        const value = data[key];
+        if (!matchesType(expected, value)) {
+          const actual = typeOf(value);
           throw new TypeError(
             `Invalid type for "${key}": expected ${expected}, got ${actual}`,
           );
@@ -51,7 +66,9 @@ class Struct {
           validate(data);
           for (let i = 0; i < fields.length; i++) {
             const key = fields[i];
-            this[key] = key in data ? data[key] : defaults[key];
+            this[key] = Object.hasOwn(data, key)
+              ? data[key]
+              : createDefault(schema[key], defaults[key]);
           }
           if (isMutable) Object.seal(this);
           else Object.freeze(this);

--- a/metautil.d.ts
+++ b/metautil.d.ts
@@ -521,13 +521,13 @@ type FieldType =
   | 'string'
   | 'number'
   | 'boolean'
-  | 'undefined'
   | 'function'
   | 'symbol'
   | 'bigint'
   | 'object'
   | 'array'
-  | 'null';
+  | 'unknown'
+  | 'ref';
 
 export type StructSchema<T extends Dictionary> = {
   readonly [K in keyof T]: FieldType;

--- a/test/struct.js
+++ b/test/struct.js
@@ -77,10 +77,10 @@ test('Struct: wrong field type throws TypeError', () => {
   );
 });
 
-test('Struct: array and null are distinguished from object', () => {
+test('Struct: array, ref, and object are distinguished', () => {
   const Data = Struct.mutable('Data', { tags: [], meta: null, info: {} });
   assert.strictEqual(Data.schema.tags, 'array');
-  assert.strictEqual(Data.schema.meta, 'null');
+  assert.strictEqual(Data.schema.meta, 'ref');
   assert.strictEqual(Data.schema.info, 'object');
   assert.throws(
     () => new Data({ tags: {} }),
@@ -230,4 +230,91 @@ test('Struct: toObject returns a plain independent copy', () => {
   assert.strictEqual(obj.constructor, Object);
   obj.name = 'Changed';
   assert.strictEqual(marcus.name, 'Marcus');
+});
+
+test('Struct: literal defaults infer schema names', () => {
+  const Example = Struct.immutable('Example', {
+    value: undefined,
+    parent: null,
+    items: [],
+    metadata: {},
+    name: '',
+    count: 0,
+    enabled: false,
+  });
+  assert.deepStrictEqual(
+    { ...Example.schema },
+    {
+      value: 'unknown',
+      parent: 'ref',
+      items: 'array',
+      metadata: 'object',
+      name: 'string',
+      count: 'number',
+      enabled: 'boolean',
+    },
+  );
+});
+
+test('Struct: undefined default accepts any value', () => {
+  const Box = Struct.immutable('Box', { value: undefined });
+  const empty = new Box();
+  assert.strictEqual(empty.value, undefined);
+  const nested = { nested: [1, null, true] };
+  const boxed = new Box({ value: nested });
+  assert.strictEqual(boxed.value, nested);
+});
+
+test('Struct: null default accepts refs and defaults to null', () => {
+  const Link = Struct.immutable('Link', {
+    head: undefined,
+    tail: null,
+  });
+  const fn = () => {};
+  const list = new Link({
+    head: 1,
+    tail: new Link({
+      head: 2,
+      tail: null,
+    }),
+  });
+  const empty = new Link();
+  assert.strictEqual(empty.tail, null);
+  assert.strictEqual(list.head, 1);
+  assert.strictEqual(list.tail.head, 2);
+  assert.strictEqual(list.tail.tail, null);
+  assert.doesNotThrow(() => new Link({ head: 0, tail: fn }));
+  assert.throws(
+    () => new Link({ head: 0, tail: 1 }),
+    new TypeError('Invalid type for "tail": expected ref, got number'),
+  );
+});
+
+test('Struct: array and object defaults are fresh per instance', () => {
+  const Node = Struct.immutable('Node', { items: [], metadata: {} });
+  const a = new Node();
+  const b = new Node();
+  assert.notStrictEqual(a.items, b.items);
+  assert.notStrictEqual(a.metadata, b.metadata);
+  assert.deepStrictEqual(a.items, []);
+  assert.deepStrictEqual(a.metadata, {});
+});
+
+test('Struct: array and object defaults validate their types', () => {
+  const TreeNode = Struct.immutable('TreeNode', {
+    children: [],
+    metadata: {},
+  });
+  assert.throws(
+    () => new TreeNode({ children: {} }),
+    new TypeError('Invalid type for "children": expected array, got object'),
+  );
+  assert.throws(
+    () => new TreeNode({ metadata: [] }),
+    new TypeError('Invalid type for "metadata": expected object, got array'),
+  );
+  assert.throws(
+    () => new TreeNode({ metadata: null }),
+    new TypeError('Invalid type for "metadata": expected object, got ref'),
+  );
 });


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
