### PR TITLE
refactor: extract assertFn and assertOptionalFn helpers in List

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -6,6 +6,15 @@ const compareAsc = (a, b) => {
   return 0;
 };
 
+const assertFn = (fn, name = 'fn') => {
+  if (typeof fn !== 'function') throw new TypeError(`${name} must be a function`);
+};
+
+const assertOptionalFn = (fn, name = 'fn') => {
+  if (fn !== undefined && typeof fn !== 'function')
+    throw new TypeError(`${name} must be a function`);
+};
+
 class ListNode {
   static fromArray(values) {
     const { length } = values;
@@ -433,6 +442,7 @@ class List {
   }
 
   groupBy(getKey) {
+    assertFn(getKey, 'getKey');
     const groups = new Map();
     let node = this.#head;
     while (node !== null) {
@@ -563,6 +573,7 @@ class List {
   }
 
   sort(compare) {
+    assertOptionalFn(compare, 'compare');
     const array = this.toArray();
     array.sort(compare);
     const { length } = array;
@@ -574,12 +585,14 @@ class List {
   }
 
   toSorted(compare) {
+    assertOptionalFn(compare, 'compare');
     const array = this.toArray();
     array.sort(compare);
     return List.fromArray(array);
   }
 
   map(fn) {
+    assertFn(fn);
     let node = this.#head;
     const list = new List();
     if (node === null) return list;
@@ -601,6 +614,7 @@ class List {
   }
 
   flatMap(fn) {
+    assertFn(fn);
     const list = new List();
     let head = null;
     let tail = null;
@@ -627,6 +641,7 @@ class List {
   }
 
   filter(fn) {
+    assertFn(fn);
     const list = new List();
     let head = null;
     let tail = null;
@@ -656,6 +671,7 @@ class List {
   }
 
   reduce(fn, initial) {
+    assertFn(fn);
     let acc = initial;
     let node = this.#head;
     let index = 0;
@@ -668,6 +684,7 @@ class List {
   }
 
   some(fn) {
+    assertFn(fn);
     let node = this.#head;
     let index = 0;
     while (node !== null) {
@@ -679,6 +696,7 @@ class List {
   }
 
   every(fn) {
+    assertFn(fn);
     let node = this.#head;
     let index = 0;
     while (node !== null) {
@@ -690,6 +708,7 @@ class List {
   }
 
   find(fn) {
+    assertFn(fn);
     const result = undefined;
     let node = this.#head;
     let index = 0;
@@ -702,6 +721,7 @@ class List {
   }
 
   findIndex(fn) {
+    assertFn(fn);
     let node = this.#head;
     let index = 0;
     while (node !== null) {
@@ -713,6 +733,7 @@ class List {
   }
 
   sum(fn) {
+    assertOptionalFn(fn);
     let total = 0;
     let node = this.#head;
     if (fn) {
@@ -735,6 +756,7 @@ class List {
   }
 
   min(compare = compareAsc) {
+    assertFn(compare, 'compare');
     let result = undefined;
     let node = this.#head;
     if (node === null) return result;
@@ -748,6 +770,7 @@ class List {
   }
 
   max(compare = compareAsc) {
+    assertFn(compare, 'compare');
     let result = undefined;
     let node = this.#head;
     if (node === null) return result;

--- a/test/list.js
+++ b/test/list.js
@@ -689,3 +689,94 @@ test('List: Symbol.iterator', () => {
   const list = List.fromArray([1, 2, 3]);
   assert.deepStrictEqual([...list], [1, 2, 3]);
 });
+// --- Argument validation ---
+
+test('List: map throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.map(42), TypeError);
+  assert.throws(() => list.map('x'), TypeError);
+  assert.throws(() => list.map(null), TypeError);
+});
+
+test('List: flatMap throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.flatMap(42), TypeError);
+  assert.throws(() => list.flatMap(null), TypeError);
+});
+
+test('List: filter throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.filter(42), TypeError);
+  assert.throws(() => list.filter(null), TypeError);
+});
+
+test('List: reduce throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.reduce(42, 0), TypeError);
+  assert.throws(() => list.reduce(null, 0), TypeError);
+});
+
+test('List: some throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.some(42), TypeError);
+  assert.throws(() => list.some(null), TypeError);
+});
+
+test('List: every throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.every(42), TypeError);
+  assert.throws(() => list.every(null), TypeError);
+});
+
+test('List: find throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.find(42), TypeError);
+  assert.throws(() => list.find(null), TypeError);
+});
+
+test('List: findIndex throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.findIndex(42), TypeError);
+  assert.throws(() => list.findIndex(null), TypeError);
+});
+
+test('List: groupBy throws TypeError if getKey is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.groupBy(42), TypeError);
+  assert.throws(() => list.groupBy(null), TypeError);
+});
+
+test('List: sum throws TypeError if fn is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.sum(42), TypeError);
+  assert.throws(() => list.sum('x'), TypeError);
+  assert.doesNotThrow(() => list.sum());
+});
+
+test('List: min throws TypeError if compare is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.min(42), TypeError);
+  assert.throws(() => list.min('x'), TypeError);
+  assert.doesNotThrow(() => list.min());
+});
+
+test('List: max throws TypeError if compare is not a function', () => {
+  const list = List.of(1, 2, 3);
+  assert.throws(() => list.max(42), TypeError);
+  assert.throws(() => list.max('x'), TypeError);
+  assert.doesNotThrow(() => list.max());
+});
+
+test('List: sort throws TypeError if compare is not a function', () => {
+  const list = List.of(3, 1, 2);
+  assert.throws(() => list.sort(42), TypeError);
+  assert.throws(() => list.sort('x'), TypeError);
+  assert.doesNotThrow(() => list.sort());
+});
+
+test('List: toSorted throws TypeError if compare is not a function', () => {
+  const list = List.of(3, 1, 2);
+  assert.throws(() => list.toSorted(42), TypeError);
+  assert.throws(() => list.toSorted('x'), TypeError);
+  assert.doesNotThrow(() => list.toSorted());
+});


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Extract assertFn and assertOptionalFn helper functions to validate
function arguments in List methods (map, filter, reduce, forEach,
find, findIndex, some, every, flatMap, groupBy, sum, min, max, sort, toSorted) instead of inline typeof checks.